### PR TITLE
Fixes to make it build and run again!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM dockerfile/python
+FROM python:2
 MAINTAINER dididi <dfdgsdfg@gmail.com>
 
 ENV HOME /root
 ENV LC_ALL C.UTF-8
+
+ARG CRAWL_VERSION=master
 
 RUN apt-get update && \
     apt-get -y install build-essential \
@@ -18,16 +20,20 @@ RUN apt-get update && \
                        libsdl2-dev \
                        libfreetype6-dev \
                        libpng-dev \
-                       ttf-dejavu-core && \
+                       ttf-dejavu-core \
+                       ccache \
+                       binutils-gold && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN pip install tornado==3.2.2
 
 WORKDIR /root
-RUN git clone git://gitorious.org/crawl/crawl.git
-
+RUN git clone https://github.com/crawl/crawl --depth 1
+ 
 WORKDIR /root/crawl
+RUN git fetch origin refs/tags/${CRAWL_VERSION}:refs/tags/${CRAWL_VERSION}
+RUN git checkout ${CRAWL_VERSION}
 RUN git submodule update --init
 
 WORKDIR /root/crawl/crawl-ref/source

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Build from the dockerfile
 ```
 $ git clone dfdgsdfg/DCSS-webtile-standalone-docker
 $ cd DCSS-webtile-standalone-docker
-$ sudo docker build -t crawl .
+$ sudo docker build --build-arg CRAWL_VERSION=0.21.1 -t crawl .
 ```
+
+If no CRAWL_VERSION is specified, it will default to master.
 
 Usage
 -----


### PR DESCRIPTION
A few fixes to make this Docker image build again.

- Need Python2
- Add a "build_arg" so that alternate versions can be specified at image build time.
- Fetch the specified target tag from origin and check it out locally
