### PR TITLE
To allow configuring target crawl git repo, add CRAWL_GIT_REPO as a BUILD_ARGUMENT, and accept either ${BRANCH} or ${

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER dididi <dfdgsdfg@gmail.com>
 ENV HOME /root
 ENV LC_ALL C.UTF-8
 
+ARG CRAWL_GIT_REPO=https://github.com/crawl/crawl
 ARG CRAWL_VERSION=master
 
 RUN apt-get update && \
@@ -29,10 +30,10 @@ RUN apt-get update && \
 RUN pip install tornado==3.2.2
 
 WORKDIR /root
-RUN git clone https://github.com/crawl/crawl --depth 1
+RUN git clone ${CRAWL_GIT_REPO} --depth 1
  
 WORKDIR /root/crawl
-RUN git fetch origin refs/tags/${CRAWL_VERSION}:refs/tags/${CRAWL_VERSION}
+RUN git fetch origin ${CRAWL_VERSION}
 RUN git checkout ${CRAWL_VERSION}
 RUN git submodule update --init
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Build from the dockerfile
 ```
 $ git clone dfdgsdfg/DCSS-webtile-standalone-docker
 $ cd DCSS-webtile-standalone-docker
-$ sudo docker build --build-arg CRAWL_VERSION=0.21.1 -t crawl .
+$ sudo docker build --build-arg CRAWL_GIT_REPO=https://github.com/Hellmonk/hellcrawl --build-arg CRAWL_VERSION=0.21.1 -t crawl .
 ```
 
-If no CRAWL_VERSION is specified, it will default to master.
+If no CRAWL_GIT_REPO is specified, it will default to 'https://github.com/crawl/crawl'.
+If no CRAWL_VERSION is specified, it will default to 'master'.
 
 Usage
 -----


### PR DESCRIPTION
In the current version of `crawl-docker`, the docker image cannot be configured to point to a repository different from mainline crawl.

As someone working on a crawl-variant for fun, having a way to specify a repository different from the mainline would simplify the build and deployment of my own crawl server.

I have added the build argument `CRAWL_GIT_REPO` to allow this. Also, to build off of branches, I had to change the fetch command.

I am actually still running into some issues with this repo (missing pyyaml) but I can resolve these separately from this addition if that makes sense.